### PR TITLE
Add python coarse-grained MD example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@
 
 
 
+
+## Simulation
+See [simulation/README.md](simulation/README.md) for running the coarse-grained MD example.

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,36 @@
+# Coarse-Grained MD Simulation with Martini
+
+This folder contains a minimal example for running a coarse-grained molecular dynamics (MD)
+simulation of Bisphenol A diglycidyl ether (DGEBA) and Hexamethylenediamine (HMDA)
+using the Martini force field in Python with [OpenMM](https://openmm.org/).
+
+The provided scripts generate a simple box filled with coarse-grained DGEBA and HMDA
+molecules (around 100k beads by default) and run a short MD simulation.
+
+## Requirements
+
+* Python 3.8 or later
+* `pip`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the simulation with:
+
+```bash
+python run_simulation.py
+```
+
+The script will output basic energy information to the console and write the final
+coordinates to `output.pdb`.
+
+## Notes
+
+The example uses a very simplified mapping and generic Martini-like parameters to
+keep the code self‑contained. For production studies you should replace the mapping
+and force field details with validated parameters.

--- a/simulation/cg_system.py
+++ b/simulation/cg_system.py
@@ -1,0 +1,70 @@
+import numpy as np
+from openmm import unit, openmm
+from openmm.app import Topology, Element
+
+# Martini-like bead parameters (simplified)
+BEAD_PARAMS = {
+    'P1': (0.47 * unit.nanometer, 5.0 * unit.kilojoule_per_mole),
+    'P2': (0.47 * unit.nanometer, 5.0 * unit.kilojoule_per_mole),
+}
+
+DGEBA_BEADS = ['P1'] * 8  # simple linear model with 8 beads
+HMDA_BEADS = ['P2'] * 4   # simple linear model with 4 beads
+
+MASS = 72.0 * unit.dalton
+BOND_LENGTH = 0.47 * unit.nanometer
+BOND_K = 1250 * unit.kilojoule_per_mole / unit.nanometer ** 2
+
+
+def build_system(num_dgeba=10000, num_hmda=5000, box_size=50.0):
+    """Create topology, system and coordinates for the CG simulation.
+
+    Parameters
+    ----------
+    num_dgeba : int
+        Number of DGEBA molecules.
+    num_hmda : int
+        Number of HMDA molecules.
+    box_size : float
+        Simulation box edge length in nanometers.
+    """
+    topology = Topology()
+    system = openmm.System()
+    nb = openmm.NonbondedForce()
+    nb.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
+    nb.setCutoffDistance(1.2 * unit.nanometer)
+    bond = openmm.HarmonicBondForce()
+
+    positions = []
+    rng = np.random.default_rng()
+
+    def add_molecule(beads):
+        chain = topology.addChain()
+        residue = topology.addResidue('MOL', chain)
+        particle_indices = []
+        base = rng.random(3) * box_size
+        for bead in beads:
+            atom = topology.addAtom(bead, Element.getByAtomicNumber(6), residue)
+            system.addParticle(MASS)
+            sigma, eps = BEAD_PARAMS[bead]
+            nb.addParticle(0.0, sigma, eps)
+            pos = base + rng.normal(scale=0.1, size=3)
+            positions.append(pos)
+            particle_indices.append(len(positions)-1)
+        for i in range(len(particle_indices)-1):
+            bond.addBond(particle_indices[i], particle_indices[i+1], BOND_LENGTH, BOND_K)
+
+    for _ in range(num_dgeba):
+        add_molecule(DGEBA_BEADS)
+    for _ in range(num_hmda):
+        add_molecule(HMDA_BEADS)
+
+    system.addForce(nb)
+    system.addForce(bond)
+    system.setDefaultPeriodicBoxVectors(
+        [box_size, 0, 0]*unit.nanometer,
+        [0, box_size, 0]*unit.nanometer,
+        [0, 0, box_size]*unit.nanometer,
+    )
+
+    return topology, system, unit.Quantity(np.array(positions), unit.nanometer)

--- a/simulation/requirements.txt
+++ b/simulation/requirements.txt
@@ -1,0 +1,2 @@
+openmm==8.2.0
+numpy

--- a/simulation/run_simulation.py
+++ b/simulation/run_simulation.py
@@ -1,0 +1,26 @@
+from sys import stdout
+from openmm import app, unit, openmm
+from cg_system import build_system
+
+# Build system with ~100k beads
+# Adjust numbers to get exactly 100k if needed
+TOP, SYS, POS = build_system(num_dgeba=10000, num_hmda=5000, box_size=50.0)
+
+integrator = openmm.LangevinMiddleIntegrator(310*unit.kelvin, 1.0/unit.picosecond, 0.02*unit.picoseconds)
+simulation = app.Simulation(TOP, SYS, integrator)
+simulation.context.setPositions(POS)
+
+print('Minimizing...')
+simulation.minimizeEnergy()
+
+simulation.reporters.append(app.StateDataReporter(stdout, 1000, step=True,
+                                                  potentialEnergy=True,
+                                                  temperature=True))
+
+print('Running MD...')
+simulation.step(5000)
+
+positions = simulation.context.getState(getPositions=True).getPositions()
+with open('output.pdb', 'w') as f:
+    app.PDBFile.writeFile(TOP, positions, f)
+print('Done. Final coordinates written to output.pdb')


### PR DESCRIPTION
## Summary
- add a new `simulation` folder with OpenMM example for Martini-style CG MD
- document install steps in `simulation/README.md`
- note the new example in the root README
- ignore `__pycache__` files

## Testing
- `python -m py_compile simulation/*.py`
- `bundle exec rake test` *(fails: missing gems)*
- `python simulation/run_simulation.py` *(fails: No module named 'openmm')*

------
https://chatgpt.com/codex/tasks/task_e_684039bab2c08330a4490659eef6a13c